### PR TITLE
Add Meilisearch to Jellyfin config

### DIFF
--- a/programs/configs/jellyfin.nix
+++ b/programs/configs/jellyfin.nix
@@ -70,5 +70,7 @@ in
         '';
       };
     };
+
+    meilisearch.enable = true;
   };
 }


### PR DESCRIPTION
Allows to use meilisearch to search through Jellyfin's collection, through the usage of the [plugin](jellyfin-plugin-meilisearch)