### PR TITLE
Add GC roots for raspi builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 test.sh
+result

--- a/programs/configs/zsh/default.nix
+++ b/programs/configs/zsh/default.nix
@@ -69,7 +69,8 @@
         update-raspi() {
           cd ~/${cfg.nixConfigsRepo}
           git pull
-          systemd-inhibit nixos-rebuild switch --target-host raspi --build-host localhost --use-remote-sudo --flake .#raspi
+          systemd-inhibit nixos-rebuild build --flake .#raspi
+          systemd-inhibit nixos-rebuild switch --target-host raspi --use-remote-sudo --flake .#raspi
         }
         upgrade() {
           cd ~/${cfg.nixConfigsRepo}

--- a/programs/configs/zsh/default.nix
+++ b/programs/configs/zsh/default.nix
@@ -97,8 +97,8 @@
         }
         tfw() {
           cdr ${cfg.mainCodingRepo.workspaceDir}
-          cargo test
           cargo fmt -- --config "${formatOptions}"
+          cargo test
           cd -
         }
         ccw() {


### PR DESCRIPTION
Don't delete derivations used for building the raspberry configuration when running nix-collect-garbage