### PR TITLE
Add autonomous worktree skill for isolated implementation workflow

### DIFF
--- a/programs/claude-code/rules/global/branch-guard.md
+++ b/programs/claude-code/rules/global/branch-guard.md
@@ -1,0 +1,5 @@
+## Branch guard
+
+Before implementing any code changes, check the current branch with `git branch --show-current`.
+
+If on `main` or `master`, do **not** implement directly — invoke the `autonomous-worktree` skill to set up a dedicated worktree first. Never commit work directly to the main branch.

--- a/programs/claude-code/skills/autonomous-worktree/SKILL.md
+++ b/programs/claude-code/skills/autonomous-worktree/SKILL.md
@@ -1,0 +1,90 @@
+---
+description: >
+  Set up an autonomous worktree workflow when implementing on main/master. Launches a sub-agent in an
+  isolated worktree, then transplants commits to a properly-named branch with PR. Invoked automatically
+  by the branch-guard rule when the agent detects it is on main or master.
+---
+
+# Autonomous Worktree
+
+Implement a task in an isolated worktree, then transplant the commits onto a properly-named branch created by the project's CLI tooling.
+
+The agent never manually creates branches, worktrees, PRs, or initial commits -- the CLI tools handle all of that.
+
+---
+
+## Phase 1 -- Work
+
+Launch an Agent sub-agent with `isolation: "worktree"`. Give it the full implementation task. The agent works freely in the isolated worktree with no naming constraints. It implements, tests, and self-reviews.
+
+On completion, the sub-agent returns:
+- The **worktree path**
+- The **branch name**
+
+This is the `source_worktree_path` for Phase 3.
+
+---
+
+## Phase 2 -- Set up real worktree
+
+Determine which CLI tool to use based on the repo context.
+
+### Stockly (main repo)
+
+Detect Stockly context by checking if `dev_tools/StocklyCli` exists in the repo root.
+
+```bash
+s wk <ticket_identifier>
+```
+
+Where `ticket_identifier` can be a Notion URL, short_id, or UUID. If a ticket/short_id already exists for the current task, use its identifier.
+
+### Personal repos
+
+```bash
+db-cli wk "descriptive title"
+```
+
+Where the title describes the task.
+
+### Parsing the worktree path from CLI output
+
+Both tools print to stderr a line in the format:
+
+```
+Worktree created. To switch to it, run:
+  cd <path> && direnv allow
+```
+
+Extract `<path>` from this output. This is the `target_worktree_path` for Phase 3.
+
+---
+
+## Phase 3 -- Transplant
+
+Run the transplant script to cherry-pick commits from the isolated worktree onto the properly-named branch:
+
+```bash
+bash "$CLAUDE_SKILL_DIR/transplant.sh" <source_worktree_path> <target_worktree_path>
+```
+
+The script:
+1. Cherry-picks all commits from the source worktree onto the target worktree
+2. Removes the source worktree and deletes its branch (automatic cleanup)
+
+If the transplant fails due to cherry-pick conflicts, investigate and resolve manually in the target worktree, then continue.
+
+---
+
+## Phase 4 -- Push
+
+```bash
+git -C <target_worktree_path> push
+```
+
+---
+
+## Error handling
+
+- **Cherry-pick conflicts**: If the transplant script exits with an error, the cherry-pick has been aborted. Investigate the conflict in the target worktree, apply the changes manually, commit, and push.
+- **CLI tool failure**: If `s wk` or `db-cli wk` fails, report the error to the user rather than attempting to create branches manually.

--- a/programs/claude-code/skills/autonomous-worktree/transplant.sh
+++ b/programs/claude-code/skills/autonomous-worktree/transplant.sh
@@ -66,9 +66,9 @@ fi
 
 # --- Cleanup: remove source worktree and its branch ---
 echo "[transplant] Removing source worktree: $source_worktree"
-git worktree remove "$source_worktree"
+git -C "$target_worktree" worktree remove "$source_worktree"
 echo "[transplant] Deleting source branch: $source_branch"
-git branch -D "$source_branch"
+git -C "$target_worktree" branch -D "$source_branch"
 
 # --- Summary ---
 target_branch="$(git -C "$target_worktree" branch --show-current)"

--- a/programs/claude-code/skills/autonomous-worktree/transplant.sh
+++ b/programs/claude-code/skills/autonomous-worktree/transplant.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_worktree="${1:?[transplant] Usage: transplant.sh <source_worktree_path> <target_worktree_path>}"
+target_worktree="${2:?[transplant] Usage: transplant.sh <source_worktree_path> <target_worktree_path>}"
+
+# --- Validate paths exist and are git worktrees ---
+for path in "$source_worktree" "$target_worktree"; do
+    if [[ ! -d "$path" ]]; then
+        echo "[transplant] Error: path does not exist: $path" >&2
+        exit 1
+    fi
+    if ! git -C "$path" rev-parse --is-inside-work-tree &>/dev/null; then
+        echo "[transplant] Error: not a git worktree: $path" >&2
+        exit 1
+    fi
+done
+
+# --- Check source has no uncommitted changes ---
+if [[ -n "$(git -C "$source_worktree" status --porcelain)" ]]; then
+    echo "[transplant] Error: source worktree has uncommitted changes: $source_worktree" >&2
+    exit 1
+fi
+
+# --- Get source branch name (fail on detached HEAD) ---
+source_branch="$(git -C "$source_worktree" branch --show-current)"
+if [[ -z "$source_branch" ]]; then
+    echo "[transplant] Error: source worktree is in detached HEAD state" >&2
+    exit 1
+fi
+
+# --- Detect main branch name ---
+main_branch=""
+if ref="$(git -C "$source_worktree" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null)"; then
+    main_branch="${ref##refs/remotes/origin/}"
+fi
+if [[ -z "$main_branch" ]]; then
+    if git -C "$source_worktree" rev-parse --verify origin/main &>/dev/null; then
+        main_branch="main"
+    elif git -C "$source_worktree" rev-parse --verify origin/master &>/dev/null; then
+        main_branch="master"
+    else
+        echo "[transplant] Error: cannot detect main branch (tried origin/main and origin/master)" >&2
+        exit 1
+    fi
+fi
+
+# --- Compute merge base ---
+merge_base="$(git -C "$source_worktree" merge-base "origin/$main_branch" HEAD)"
+
+# --- Get commit list ---
+mapfile -t commits < <(git -C "$source_worktree" rev-list --reverse "$merge_base..HEAD")
+commit_count="${#commits[@]}"
+
+# --- Cherry-pick onto target ---
+if [[ "$commit_count" -eq 0 ]]; then
+    echo "[transplant] No commits to transplant."
+else
+    echo "[transplant] Transplanting $commit_count commit(s) onto target..."
+    if ! git -C "$target_worktree" cherry-pick "${commits[@]}" 2>&1; then
+        echo "[transplant] Error: cherry-pick failed due to conflict. Aborting cherry-pick." >&2
+        git -C "$target_worktree" cherry-pick --abort 2>/dev/null || true
+        exit 1
+    fi
+fi
+
+# --- Cleanup: remove source worktree and its branch ---
+echo "[transplant] Removing source worktree: $source_worktree"
+git worktree remove "$source_worktree"
+echo "[transplant] Deleting source branch: $source_branch"
+git branch -D "$source_branch"
+
+# --- Summary ---
+target_branch="$(git -C "$target_worktree" branch --show-current)"
+echo "[transplant] Done. $commit_count commit(s) transplanted onto branch: $target_branch"


### PR DESCRIPTION
Bridge Claude Code's `isolation: "worktree"` with the project's branch-naming and PR-creation tooling (`db-cli wk` / `s wk`).

**What's new:**

- **Branch-guard rule** — always-loaded rule that prevents implementing directly on `main`/`master`, redirecting to the autonomous-worktree skill instead
- **Autonomous-worktree skill** — 4-phase workflow: (1) implement in an isolated worktree, (2) create a properly-named worktree via CLI, (3) transplant commits, (4) push
- **Transplant script** — cherry-picks commits from an isolated worktree onto a target worktree, with edge-case handling (conflicts, detached HEAD, dirty source, no commits)