### PR TITLE
Restore music-title config in waybar

### DIFF
--- a/programs/waybar/default.nix
+++ b/programs/waybar/default.nix
@@ -45,6 +45,15 @@
       '';
     in
     {
+      byDbPkgs.music-title = {
+        enable = true;
+        currentSongsDir = "${config.home.homeDirectory}/.config/by_db/music_title";
+        radioFrance = {
+          apiKeyFile = config.byDb.secrets.radioFranceApiKey;
+          url = "https://openapi.radiofrance.fr/v1/graphql";
+        };
+      };
+
       programs.waybar = {
         enable = true;
         systemd.enable = true;


### PR DESCRIPTION
The `byDbPkgs.music-title` config block was accidentally dropped during the X11-to-Wayland migration (`b8f74e8`). This block generates `~/.config/by_db/music-title.toml` (RadioFrance API URL + key), without which `music-title` silently fails and waybar shows no song info.