### PR TITLE
Fix URL click: use Kitty's Ctrl+Shift+Click instead of Neovim keymap

### DIFF
--- a/programs/kitty/default.nix
+++ b/programs/kitty/default.nix
@@ -33,6 +33,9 @@ in
       size = 10;
     };
     settings = {
+      # Ctrl+Click doesn't work inside Neovim because syntax highlighting
+      # breaks Kitty's URL detection. Ctrl+Shift+Click works everywhere.
+      open_url_modifiers = "ctrl+shift";
       background_opacity = "0.8";
       editor = "nvim";
       hide_window_decorations = "no";

--- a/programs/neovim/default.nix
+++ b/programs/neovim/default.nix
@@ -25,16 +25,6 @@
           transparent_background = true,
       })
       require('render-markdown').setup({})
-
-      -- Open URLs with mouse click instead of tag lookup
-      vim.keymap.set('n', '<C-LeftMouse>', function()
-        -- Move cursor to click position, then open URL
-        vim.cmd('normal! <LeftMouse>')
-        local url = vim.fn.expand('<cWORD>')
-        if url:match('^https?://') then
-          vim.ui.open(url)
-        end
-      end, { desc = 'Open URL under cursor' })
     '';
   };
 }


### PR DESCRIPTION
## Summary
- Remove the broken Neovim `<C-LeftMouse>` keymap — Kitty intercepts Ctrl+Click before Neovim sees it, so no Neovim-side fix can work
- Set `open_url_modifiers = "ctrl+shift"` in Kitty so that Ctrl+Shift+Click opens URLs everywhere, including inside Neovim

🤖 Generated with [Claude Code](https://claude.com/claude-code)