### PR TITLE
Fix Ranger editor when launched via Sway keybinding

### DIFF
--- a/nixos/workstation.nix
+++ b/nixos/workstation.nix
@@ -66,6 +66,8 @@
 
       environment = {
         sessionVariables = {
+          EDITOR = "nvim";
+
           NIXOS_OZONE_WL = "1";
           MOZ_ENABLE_WAYLAND = "1";
           QT_QPA_PLATFORM = "wayland";

--- a/nixos/workstation.nix
+++ b/nixos/workstation.nix
@@ -66,7 +66,6 @@
 
       environment = {
         sessionVariables = {
-          EDITOR = "nvim";
           NIXOS_OZONE_WL = "1";
           MOZ_ENABLE_WAYLAND = "1";
           QT_QPA_PLATFORM = "wayland";

--- a/nixos/workstation.nix
+++ b/nixos/workstation.nix
@@ -67,7 +67,6 @@
       environment = {
         sessionVariables = {
           EDITOR = "nvim";
-
           NIXOS_OZONE_WL = "1";
           MOZ_ENABLE_WAYLAND = "1";
           QT_QPA_PLATFORM = "wayland";

--- a/programs/ranger/workstation.nix
+++ b/programs/ranger/workstation.nix
@@ -34,7 +34,7 @@ in
 
   wayland.windowManager.sway.config.keybindings = lib.mkOptionDefault {
     "${modifier}+Control+r" =
-      ''workspace "${ws."7"}"; exec kitty --title "Ranger ($(hostname))" -e ranger'';
+      ''workspace "${ws."7"}"; exec kitty --title "Ranger ($(hostname))" -e zsh -c ranger'';
     "${modifier}+Shift+r" = "workspace \"${ws."7"}\"; exec ${openRemote}";
   };
 }


### PR DESCRIPTION
## Summary
- Ranger opened files with nano instead of nvim when launched via the Sway shortcut (mod+ctrl+r), because `kitty -e ranger` bypasses zsh and never sources `.zshenv` where `EDITOR=nvim` is set
- Changed to `kitty -e zsh -c ranger` so the shell environment is loaded
- Removed redundant `EDITOR = "nvim"` session variable (already handled by `programs.neovim.defaultEditor = true`)