### PR TITLE
Revamp Claude & Cursor launch with sway modes

### DIFF
--- a/programs/claude-code/terminal-title.nix
+++ b/programs/claude-code/terminal-title.nix
@@ -91,16 +91,6 @@ in
 
       _auto_title_preexec() {
         local title="$1"
-        if [[ "$title" == claude-orthos* ]]; then
-          local args="''${title#claude-orthos}"
-          args="''${args# }"
-          if [[ -n "$args" ]]; then
-            print -Pn "\e]2;Claude (orthos: $args)\a"
-          else
-            print -Pn "\e]2;Claude (orthos: Main)\a"
-          fi
-          return
-        fi
         [[ "$title" == claude* ]] && title="Claude"
         print -Pn "\e]2;$title$(_title_suffix)\a"
       }

--- a/programs/claude-code/workstation.nix
+++ b/programs/claude-code/workstation.nix
@@ -81,7 +81,8 @@ let
   claudeNixOrthos = mkOpenScript {
     scriptName = "claude-nix-orthos";
     host = "orthos";
-    basePath = "/home/romain/nix-configs";
+    basePath = "/home/romain";
+    worktreePrefix = "nix-configs";
   };
   claudeNixSalon = mkOpenScript {
     scriptName = "claude-nix-salon";

--- a/programs/claude-code/workstation.nix
+++ b/programs/claude-code/workstation.nix
@@ -1,35 +1,113 @@
-{ ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (config.byDb) modifier ws paths;
+  rofi = config.rofi.defaultCmd;
+  # Lists worktree display names: prefix stays as-is, prefix_foo becomes "foo"
+  # $1 = base path, $2 = prefix (default: Main)
+  listWorktreeNames = pkgs.writeScript "list-worktree-names" ''
+    #!/usr/bin/env bash
+    prefix="''${2:-Main}"
+    cd "$1" && {
+      for d in "$prefix" "''${prefix}_"*; do
+        [ -d "$d" ] && echo "$d"
+      done
+    } | LC_ALL=C sort -fu | sed "s/^''${prefix}_//"
+  '';
+  mkOpenScript =
+    {
+      scriptName,
+      host ? null,
+      basePath,
+      rofiWidth ? "20%",
+      worktreePrefix ? "Main",
+    }:
+    let
+      isRemote = host != null;
+      fetchNames =
+        if isRemote then
+          "timeout 5 ssh -o ConnectTimeout=5 ${host} bash -s -- ${basePath} ${worktreePrefix} < ${listWorktreeNames} 2>/dev/null"
+        else
+          "${listWorktreeNames} ${basePath} ${worktreePrefix} 2>/dev/null";
+      openTarget =
+        if isRemote then
+          ''kitty --title "Claude (${host}: $name)" kitten ssh ${host} -t "cd '$path' && claude; exec \$SHELL"''
+        else
+          ''kitty --title "Claude ($name)" -e zsh -c "cd '$path' && claude"'';
+    in
+    "${pkgs.writeScriptBin scriptName ''
+      names=$(${fetchNames})
+      ${lib.optionalString isRemote ''
+        if [[ $? -ne 0 ]]; then
+          ${pkgs.libnotify}/bin/notify-send -u critical "${scriptName}" "${host} is unreachable"
+          exit 1
+        fi
+      ''}
+      if [[ $(echo "$names" | wc -l) -le 1 ]]; then
+        name="$names"
+      else
+        name=$(echo "$names" | ${rofi} -theme-str 'window {width: ${rofiWidth};}')
+      fi
+      if [[ -n "$name" ]]; then
+        [[ "$name" == "${worktreePrefix}" ]] && worktree="${worktreePrefix}" || worktree="${worktreePrefix}_$name"
+        path="${basePath}/$worktree"
+        ${openTarget}
+      fi
+    ''}/bin/${scriptName}";
+  claudeLocal = mkOpenScript {
+    scriptName = "claude-local";
+    basePath = paths.codeRoot;
+  };
+  claudeOrthos = mkOpenScript {
+    scriptName = "claude-orthos";
+    host = "orthos";
+    basePath = "/home/romain/Stockly";
+    rofiWidth = "30%";
+  };
+  claudeSalon = mkOpenScript {
+    scriptName = "claude-salon";
+    host = "salon";
+    basePath = "/home/romain/code";
+  };
+  claudeNixLocal = mkOpenScript {
+    scriptName = "claude-nix-local";
+    basePath = paths.codeRoot;
+    worktreePrefix = "nix-configs";
+  };
+  claudeNixOrthos = mkOpenScript {
+    scriptName = "claude-nix-orthos";
+    host = "orthos";
+    basePath = "/home/romain/nix-configs";
+  };
+  claudeNixSalon = mkOpenScript {
+    scriptName = "claude-nix-salon";
+    host = "salon";
+    basePath = "/home/romain/code";
+    worktreePrefix = "nix-configs";
+  };
+in
 {
   imports = [ ./common.nix ];
 
-  programs.zsh = {
-    enable = true;
-    initContent = ''
-      claude-orthos() {
-        local short_id="$1"
-        local base="/home/romain/Stockly"
-
-        if [[ -z "$short_id" ]]; then
-          ssh -t orthos "printf '\033]2;* Claude Code (orthos: Main)\007' && cd '$base/Main' && claude; exec \$SHELL"
-          return
-        fi
-
-        if [[ ! "$short_id" =~ ^[A-Za-z0-9]{5}$ ]]; then
-          echo "Error: '$short_id' is not a valid short ID (must be exactly 5 alphanumeric characters)" >&2
-          return 1
-        fi
-
-        ssh -t orthos "
-          dir=\$(find '$base' -maxdepth 1 -type d -name 'Main_$short_id-*' | head -1)
-          if [[ -z \"\$dir\" ]]; then
-            echo \"Error: no directory found for short ID '$short_id'\" >&2
-            exit 1
-          fi
-          printf '\033]2;* Claude Code (orthos: %s)\007' \"\$(basename \"\$dir\" | sed 's/^Main_//')\"
-          cd \"\$dir\" && claude; exec \$SHELL
-        "
-      }
-      alias co='claude-orthos'
-    '';
+  wayland.windowManager.sway.config = {
+    keybindings = lib.mkOptionDefault {
+      "${modifier}+Control+a" = ''mode "claude"'';
+    };
+    modes = {
+      claude = {
+        "Control+c" = ''workspace "${ws."1"}"; exec ${claudeLocal}, mode default'';
+        "Shift+c" = ''workspace "${ws."1"}"; exec ${claudeOrthos}, mode default'';
+        "Mod1+c" = ''workspace "${ws."1"}"; exec ${claudeSalon}, mode default'';
+        "Control+n" = ''workspace "${ws."1"}"; exec ${claudeNixLocal}, mode default'';
+        "Shift+n" = ''workspace "${ws."1"}"; exec ${claudeNixOrthos}, mode default'';
+        "Mod1+n" = ''workspace "${ws."1"}"; exec ${claudeNixSalon}, mode default'';
+        "Escape" = "mode default";
+        "Return" = "mode default";
+      };
+    };
   };
 }

--- a/programs/claude-code/workstation.nix
+++ b/programs/claude-code/workstation.nix
@@ -81,7 +81,7 @@ let
   claudeNixOrthos = mkOpenScript {
     scriptName = "claude-nix-orthos";
     host = "orthos";
-    basePath = "/home/romain";
+    basePath = "/home/romain/code";
     worktreePrefix = "nix-configs";
   };
   claudeNixSalon = mkOpenScript {

--- a/programs/claude-code/workstation.nix
+++ b/programs/claude-code/workstation.nix
@@ -96,10 +96,10 @@ in
 
   wayland.windowManager.sway.config = {
     keybindings = lib.mkOptionDefault {
-      "${modifier}+Control+a" = ''mode "claude"'';
+      "${modifier}+Control+a" = ''mode "Claude: [c]ode, [n]ix"'';
     };
     modes = {
-      claude = {
+      "Claude: [c]ode, [n]ix" = {
         "Control+c" = ''workspace "${ws."1"}"; exec ${claudeLocal}, mode default'';
         "Shift+c" = ''workspace "${ws."1"}"; exec ${claudeOrthos}, mode default'';
         "Mod1+c" = ''workspace "${ws."1"}"; exec ${claudeSalon}, mode default'';

--- a/programs/cursor/default.nix
+++ b/programs/cursor/default.nix
@@ -120,7 +120,7 @@ let
   openNixOrthos = mkOpenScript {
     scriptName = "open-nix-orthos";
     host = "orthos";
-    basePath = "/home/romain";
+    basePath = "/home/romain/code";
     worktreePrefix = "nix-configs";
     skipSubdirs = true;
   };

--- a/programs/cursor/default.nix
+++ b/programs/cursor/default.nix
@@ -64,7 +64,11 @@ let
           ''cursor "$path"'';
       subdirBlock = ''
         subdirs=$(${fetchSubdirs})
-        subdir=$(echo "$subdirs" | ${rofi} -theme-str 'window {width: ${rofiWidth};}')
+        if [[ $(echo "$subdirs" | wc -l) -le 1 ]]; then
+          subdir="$subdirs"
+        else
+          subdir=$(echo "$subdirs" | ${rofi} -theme-str 'window {width: ${rofiWidth};}')
+        fi
         if [[ -z "$subdir" ]]; then exit 0; fi
         path="${basePath}/$worktree"
         [[ "$subdir" != "Root" ]] && path="$path/$subdir"
@@ -80,7 +84,12 @@ let
           ${pkgs.libnotify}/bin/notify-send -u critical "${scriptName}" "${host} is unreachable"
           exit 1
         fi
-      ''}name=$(echo "$names" | ${rofi} -theme-str 'window {width: ${rofiWidth};}')
+      ''}
+      if [[ $(echo "$names" | wc -l) -le 1 ]]; then
+        name="$names"
+      else
+        name=$(echo "$names" | ${rofi} -theme-str 'window {width: ${rofiWidth};}')
+      fi
       if [[ -n "$name" ]]; then
         [[ "$name" == "${worktreePrefix}" ]] && worktree="${worktreePrefix}" || worktree="${worktreePrefix}_$name"
         ${if skipSubdirs then directBlock else subdirBlock}
@@ -105,6 +114,13 @@ let
   openNixLocal = mkOpenScript {
     scriptName = "open-nix-local";
     basePath = paths.codeRoot;
+    worktreePrefix = "nix-configs";
+    skipSubdirs = true;
+  };
+  openNixOrthos = mkOpenScript {
+    scriptName = "open-nix-orthos";
+    host = "orthos";
+    basePath = "/home/romain/nix-configs";
     worktreePrefix = "nix-configs";
     skipSubdirs = true;
   };
@@ -139,13 +155,19 @@ in
       "\"${ws."3"}\"" = [ { class = "Cursor"; } ];
     };
     keybindings = lib.mkOptionDefault {
-      "${modifier}+Control+v" = "workspace \"${ws."3"}\"; exec ${openLocal}";
-      "${modifier}+Shift+v" = "workspace \"${ws."3"}\"; exec ${openOrthos}";
-      "${modifier}+Mod1+v" = "workspace \"${ws."3"}\"; exec ${openSalon}";
-      "${modifier}+Control+n" = "workspace \"${ws."3"}\"; exec ${openNixLocal}";
-      "${modifier}+Shift+n" =
-        "workspace \"${ws."3"}\"; exec cursor --folder-uri=vscode-remote://ssh-remote+orthos/home/romain/nix-configs";
-      "${modifier}+Mod1+n" = "workspace \"${ws."3"}\"; exec ${openNixSalon}";
+      "${modifier}+Control+v" = ''mode "cursor"'';
+    };
+    modes = {
+      cursor = {
+        "Control+c" = ''workspace "${ws."3"}"; exec ${openLocal}, mode default'';
+        "Shift+c" = ''workspace "${ws."3"}"; exec ${openOrthos}, mode default'';
+        "Mod1+c" = ''workspace "${ws."3"}"; exec ${openSalon}, mode default'';
+        "Control+n" = ''workspace "${ws."3"}"; exec ${openNixLocal}, mode default'';
+        "Shift+n" = ''workspace "${ws."3"}"; exec ${openNixOrthos}, mode default'';
+        "Mod1+n" = ''workspace "${ws."3"}"; exec ${openNixSalon}, mode default'';
+        "Escape" = "mode default";
+        "Return" = "mode default";
+      };
     };
   };
 }

--- a/programs/cursor/default.nix
+++ b/programs/cursor/default.nix
@@ -120,7 +120,7 @@ let
   openNixOrthos = mkOpenScript {
     scriptName = "open-nix-orthos";
     host = "orthos";
-    basePath = "/home/romain/nix-configs";
+    basePath = "/home/romain";
     worktreePrefix = "nix-configs";
     skipSubdirs = true;
   };

--- a/programs/cursor/default.nix
+++ b/programs/cursor/default.nix
@@ -155,7 +155,7 @@ in
       "\"${ws."3"}\"" = [ { class = "Cursor"; } ];
     };
     keybindings = lib.mkOptionDefault {
-      "${modifier}+Control+v" = ''mode "cursor"'';
+      "${modifier}+Control+v" = ''mode "Cursor: [c]ode, [n]ix"'';
     };
     modes = {
       cursor = {

--- a/programs/cursor/default.nix
+++ b/programs/cursor/default.nix
@@ -158,7 +158,7 @@ in
       "${modifier}+Control+v" = ''mode "Cursor: [c]ode, [n]ix"'';
     };
     modes = {
-      cursor = {
+      "Cursor: [c]ode, [n]ix" = {
         "Control+c" = ''workspace "${ws."3"}"; exec ${openLocal}, mode default'';
         "Shift+c" = ''workspace "${ws."3"}"; exec ${openOrthos}, mode default'';
         "Mod1+c" = ''workspace "${ws."3"}"; exec ${openSalon}, mode default'';

--- a/programs/zsh/home-manager.nix
+++ b/programs/zsh/home-manager.nix
@@ -27,7 +27,6 @@ in
       ssh = "kitten ssh";
       cargo2nix = "cdr && cargo2nix -ol && cd -";
       dc = "db-cli";
-      con = "cdn && claude";
 
       # Nix
       update = "run-in-nix-repo nix-switch";


### PR DESCRIPTION
## Summary
- Replace `claude-orthos`/`co` shell function and `con` alias with rofi-based launch scripts + sway mode (`Mod+Ctrl+a`)
- Refactor Cursor's 6 individual keybindings (`Mod+Ctrl/Shift/Alt+v/n`) into a sway mode (`Mod+Ctrl+v`)
- Add worktree selection for nix-configs on orthos (was hardcoded to main before)
- Skip rofi menu when there's only one worktree (or one subdirectory for Cursor)