### PR TITLE
Add asana-dispatch skill with systemd timer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1776241766,
-        "narHash": "sha256-OfrYY9cmLYaUzXRkPtVTJj+ZLQ7vUiKweHrEBE0XX4U=",
+        "lastModified": 1776261150,
+        "narHash": "sha256-pI344qzKQN5OyEBrifrd1SgG0zPuoAyBZV4K5nBk5/0=",
         "ref": "refs/heads/main",
-        "rev": "461671388e9db8247907c0c9d0eab53f71a0304e",
-        "revCount": 199,
+        "rev": "75347fca83958ea9c2117b0136f3999e69fb3454",
+        "revCount": 202,
         "type": "git",
         "url": "ssh://git@github.com/bebert64/perso"
       },
@@ -283,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772420823,
-        "narHash": "sha256-q3oVwz1Rx41D1D+F6vg41kpOkk3Zi3KwnkHEZp7DCGs=",
+        "lastModified": 1776222810,
+        "narHash": "sha256-5TD8MYqLMcJi9yV/9jq2dVUPtnu/lKZPD61esQCgvqs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "458eea8d905c609e9d889423e6b8a1c7bc2f792c",
+        "rev": "4d6fee71fea68418a48992409b47f1183d0dd111",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1776166537,
-        "narHash": "sha256-LwTlSSyDWpPGss57HROpPO6gMwhbx2JZZ/5rUtnNZqk=",
+        "lastModified": 1776241766,
+        "narHash": "sha256-OfrYY9cmLYaUzXRkPtVTJj+ZLQ7vUiKweHrEBE0XX4U=",
         "ref": "refs/heads/main",
-        "rev": "30559c654687a51d61235936a2cabcf87f810678",
-        "revCount": 198,
+        "rev": "461671388e9db8247907c0c9d0eab53f71a0304e",
+        "revCount": 199,
         "type": "git",
         "url": "ssh://git@github.com/bebert64/perso"
       },

--- a/home-manager/workstation.nix
+++ b/home-manager/workstation.nix
@@ -108,6 +108,16 @@
       };
 
       byDbPkgs = {
+        asana-cli = {
+          enable = true;
+          tokenFile = config.sops.secrets."code/mcp/asana-token".path;
+          projects = [
+            {
+              name = "nix-and-code";
+              gid = "1208698992717829";
+            }
+          ];
+        };
         db-cli = {
           enable = true;
         };

--- a/programs/claude-code/common.nix
+++ b/programs/claude-code/common.nix
@@ -89,11 +89,7 @@ let
       }
     )
   );
-  claudeWithVoice = pkgs.writeShellScriptBin "claude" ''
-    # PulseAudio forwarding for Claude Code voice mode on monsters
-    if [ -S /tmp/pulse-forward ]; then
-      export PULSE_SERVER=unix:/tmp/pulse-forward
-    fi
+  claudeWrapper = pkgs.writeShellScriptBin "claude" ''
     exec ${pkgsUnstable.claude-code}/bin/claude --dangerously-skip-permissions "$@"
   '';
 in
@@ -102,8 +98,7 @@ in
 
   home = {
     packages = [
-      claudeWithVoice
-      pkgs.sox
+      claudeWrapper
     ];
     activation = {
       symlinkClaudeSettings = lib.hm.dag.entryAfter [ "writeBoundary" "setupSecrets" ] ''

--- a/programs/claude-code/rules/global/branch-guard.md
+++ b/programs/claude-code/rules/global/branch-guard.md
@@ -1,5 +1,5 @@
 ## Branch guard
 
-Before implementing any code changes, check the current branch with `git branch --show-current`.
+Before editing any files, check the current branch with `git branch --show-current`.
 
-If on `main` or `master`, do **not** implement directly — invoke the `autonomous-worktree` skill to set up a dedicated worktree first. Never commit work directly to the main branch.
+If on `main` or `master`, do **not** edit directly — invoke the `autonomous-worktree` skill to set up a dedicated worktree first. Never commit work directly to the main branch. This applies to all files: code, skills, configs, documentation, rules — anything that would result in a commit.

--- a/programs/claude-code/skills/asana-dispatch/SKILL.md
+++ b/programs/claude-code/skills/asana-dispatch/SKILL.md
@@ -1,0 +1,194 @@
+---
+description: >
+  Fetch tasks from Asana and dispatch sub-agents to plan or ship them.
+  Trigger: /asana-dispatch or recurring cron schedule.
+---
+
+# Asana Dispatch
+
+Fetch tasks from Asana board sections and dispatch sub-agents to either produce implementation plans or ship end-to-end. Move completed tasks to review sections.
+
+---
+
+## Section mapping
+
+| Input section | Workflow | Output section (success) |
+|---|---|---|
+| Need plan | Planning sub-agent | Review plan |
+| Ready to implement | `/ship` sub-agent | Review code |
+
+Tasks missing a target repo → moved to **To fix**.
+
+---
+
+## Step 1 — Discover and ensure sections
+
+List all sections for the project:
+
+```bash
+asana sections list nix-and-code
+```
+
+Parse the JSON output to build a **name → GID** map. Required sections:
+- **Input:** `Need plan`, `Ready to implement`
+- **Output:** `Review plan`, `Review code`, `To fix`
+
+**Auto-create missing output sections:**
+
+```bash
+asana sections create nix-and-code "Review plan"
+asana sections create nix-and-code "Review code"
+asana sections create nix-and-code "To fix"
+```
+
+If an input section is missing, warn and skip it (no tasks to process).
+
+---
+
+## Step 2 — Fetch tasks from input sections
+
+```bash
+asana tasks list nix-and-code --section "Need plan"
+asana tasks list nix-and-code --section "Ready to implement"
+```
+
+For each task in either section, fetch full details:
+
+```bash
+asana tasks get <task_gid>
+```
+
+This returns the task name, description, subtasks, and completed status as JSON.
+
+Collect all tasks into two lists: `plan_tasks` and `ship_tasks`.
+
+---
+
+## Step 3 — Validate target repo
+
+For each task, parse its **description** for an explicit repo mention.
+
+Recognized values:
+- `nix-configs` or `nix_configs` → `/home/romain/code/nix-configs`
+- `Main` → `/home/romain/code/Main`
+
+**Case-insensitive match.** Look for these as standalone words or path components in the description text.
+
+If no repo is found:
+1. Move the task to "To fix" (see Step 5)
+2. Log: `"Task '<name>' has no target repo in description — moved to To fix"`
+3. Skip to next task
+
+---
+
+## Step 4 — Dispatch sub-agents
+
+Launch up to **4 sub-agents concurrently** (mix of plan and ship tasks).
+
+### For "Need plan" tasks
+
+Launch a sub-agent per task with this prompt:
+
+> You are a planning agent. Your job is to produce a complete, detailed, implementation-ready plan. Do NOT write any code. Do NOT create branches.
+>
+> **Task from Asana:**
+> - Title: `<task_name>`
+> - Description: `<task_description>`
+> - Subtasks: `<subtask_list>` (use these as chunking hints)
+>
+> **Target repo:** `<repo_path>`
+>
+> **Instructions:**
+> 1. `cd <repo_path>`
+> 2. Read `AGENTS.md` at the repo root if it exists.
+> 3. Read `~/.claude/docs/README.md` and any relevant docs.
+> 4. Read ALL relevant source files — existing behavior, data structures, API surfaces, tests.
+> 5. Write a detailed implementation plan at `~/.claude/plans/<slug>.md` following the standard format:
+>    - `## Branch`, `## Short ID`, `## Category` headers
+>    - Numbered top-level steps (1., 2., 3.) with lettered sub-points (A, B, C)
+>    - A `## Chunks` section grouping work into independently-shippable units sized for a single sub-agent (1–3 files each), with an explicit dependency graph
+> 6. Update `~/.claude/plans/_index.json`.
+> 7. Return: the plan file path and a summary of what was planned.
+>
+> Make the plan as detailed as possible. Every chunk should specify exact file paths to create/modify, the logic to implement, and how to verify.
+
+### For "Ready to implement" tasks
+
+Launch a sub-agent per task with this prompt:
+
+> You have a task to implement end-to-end.
+>
+> **Task from Asana:**
+> - Title: `<task_name>`
+> - Description: `<task_description>`
+> - Subtasks: `<subtask_list>`
+>
+> **Target repo:** `<repo_path>`
+>
+> **Instructions:**
+> 1. `cd <repo_path>`
+> 2. Invoke `/ship` with the following task description:
+>
+> `<task_name>: <task_description>`
+>
+> The ship workflow handles everything: planning, implementation, testing, and self-review.
+>
+> 3. Return: summary of what was implemented, commit hashes, and any open points.
+
+---
+
+## Step 5 — Move tasks on completion
+
+Moving a task = **create** in target section + **delete** original.
+
+```bash
+# Create in target section (preserving name and description)
+asana tasks create nix-and-code "<task_name>" --section "<target_section>" --description "<original_description>"
+
+# Delete original
+asana tasks delete <original_task_gid>
+```
+
+**Mapping:**
+
+| Source section | On success | On missing repo |
+|---|---|---|
+| Need plan | → Review plan | → To fix |
+| Ready to implement | → Review code | → To fix |
+
+**On sub-agent failure:** do NOT move the task. Leave it in its current section so it can be retried.
+
+---
+
+## Step 6 — Report
+
+As each sub-agent completes, immediately report:
+- Task name
+- Outcome: success or failure (with error summary if failed)
+- Section moved to (or "not moved" if failed)
+
+After all sub-agents finish, display a summary table:
+
+| # | Task | Source | Outcome | Moved to |
+|---|------|--------|---------|----------|
+
+---
+
+## Error handling
+
+- **`asana` CLI not found:** Fail immediately with `"asana CLI not installed — install it and retry"`.
+- **Sub-agent failure:** Do not move the task. Report the error. Continue with remaining tasks.
+- **Empty input sections:** Report "No tasks in <section>" and finish cleanly.
+- **Asana API error:** Report the error from the CLI stderr and skip the affected task.
+
+---
+
+## Cron setup
+
+To run this skill automatically on weekday mornings:
+
+```
+CronCreate with cron: "17 9 * * 1-5", prompt: "/asana-dispatch", recurring: true
+```
+
+Note: cron jobs are session-scoped and auto-expire after 7 days. Re-create on new sessions as needed.

--- a/programs/claude-code/skills/asana-dispatch/SKILL.md
+++ b/programs/claude-code/skills/asana-dispatch/SKILL.md
@@ -12,10 +12,10 @@ Fetch tasks from Asana board sections and dispatch sub-agents to either produce 
 
 ## Section mapping
 
-| Input section | Workflow | Output section (success) |
-|---|---|---|
-| Need plan | Planning sub-agent | Review plan |
-| Ready to implement | `/ship` sub-agent | Review code |
+| Input section      | Workflow           | Output section (success) |
+| ------------------ | ------------------ | ------------------------ |
+| Ready to plan      | Planning sub-agent | Review plan              |
+| Ready to implement | `/ship` sub-agent  | Review code              |
 
 Tasks missing a target repo → moved to **To fix**.
 
@@ -30,7 +30,8 @@ asana-cli sections list nix-and-code
 ```
 
 Parse the JSON output to build a **name → GID** map. Required sections:
-- **Input:** `Need plan`, `Ready to implement`
+
+- **Input:** `Ready to plan`, `Ready to implement`
 - **Output:** `Review plan`, `Review code`, `To fix`
 
 **Auto-create missing output sections:**
@@ -48,7 +49,7 @@ If an input section is missing, warn and skip it (no tasks to process).
 ## Step 2 — Fetch tasks from input sections
 
 ```bash
-asana-cli tasks list nix-and-code --section "Need plan"
+asana-cli tasks list nix-and-code --section "Ready to plan"
 asana-cli tasks list nix-and-code --section "Ready to implement"
 ```
 
@@ -64,10 +65,11 @@ Launch up to **4 sub-agents concurrently** (mix of plan and ship tasks).
 
 Each sub-agent is responsible for fetching its own task details and determining the target repo. The main agent only passes the **task GID** and **task name**.
 
-- **"Need plan" tasks** → use the prompt template in [`plan-agent.md`](plan-agent.md)
+- **"Ready to plan" tasks** → use the prompt template in [`plan-agent.md`](plan-agent.md)
 - **"Ready to implement" tasks** → use the prompt template in [`ship-agent.md`](ship-agent.md)
 
 If a sub-agent returns `"AMBIGUOUS_REPO"`, treat it as a repo-resolution failure (see Step 4).
+If a sub-agent returns `"NEEDS_INPUT"`, treat it as a blocked-on-human case (see Step 4).
 
 ---
 
@@ -85,12 +87,14 @@ asana-cli tasks delete <original_task_gid>
 
 **Mapping:**
 
-| Source section | On success | On ambiguous repo | On failure |
-|---|---|---|---|
-| Need plan | → Review plan | → To fix | Stay in place |
-| Ready to implement | → Review code | → To fix | Stay in place |
+| Source section     | On success    | On ambiguous repo | On needs input | On failure    |
+| ------------------ | ------------- | ----------------- | -------------- | ------------- |
+| Ready to plan      | → Review plan | → To fix          | —              | Stay in place |
+| Ready to implement | → Review code | → To fix          | → Review plan  | Stay in place |
 
 **On `AMBIGUOUS_REPO` result:** Move the task to "To fix". Append the sub-agent's ambiguity explanation to the task description (do not overwrite). Log: `"Task '<name>' — ambiguous target repo, moved to To fix"`.
+
+**On `NEEDS_INPUT` result:** Move the task to "Review plan". The sub-agent has already uploaded the plan and updated the description with the blockers. Log: `"Task '<name>' — blocked on human input, moved to Review plan"`.
 
 **On sub-agent failure:** do NOT move the task. Leave it in its current section so it can be retried.
 
@@ -99,14 +103,15 @@ asana-cli tasks delete <original_task_gid>
 ## Step 5 — Report
 
 As each sub-agent completes, immediately report:
+
 - Task name
 - Outcome: success or failure (with error summary if failed)
 - Section moved to (or "not moved" if failed)
 
 After all sub-agents finish, display a summary table:
 
-| # | Task | Source | Outcome | Moved to |
-|---|------|--------|---------|----------|
+| #   | Task | Source | Outcome | Moved to |
+| --- | ---- | ------ | ------- | -------- |
 
 ---
 
@@ -118,13 +123,3 @@ After all sub-agents finish, display a summary table:
 - **Asana API error:** Report the error from the CLI stderr and skip the affected task.
 
 ---
-
-## Cron setup
-
-To run this skill automatically on weekday mornings:
-
-```
-CronCreate with cron: "17 9 * * 1-5", prompt: "/asana-dispatch", recurring: true
-```
-
-Note: cron jobs are session-scoped and auto-expire after 7 days. Re-create on new sessions as needed.

--- a/programs/claude-code/skills/asana-dispatch/SKILL.md
+++ b/programs/claude-code/skills/asana-dispatch/SKILL.md
@@ -26,7 +26,7 @@ Tasks missing a target repo → moved to **To fix**.
 List all sections for the project:
 
 ```bash
-asana sections list nix-and-code
+asana-cli sections list nix-and-code
 ```
 
 Parse the JSON output to build a **name → GID** map. Required sections:
@@ -36,9 +36,9 @@ Parse the JSON output to build a **name → GID** map. Required sections:
 **Auto-create missing output sections:**
 
 ```bash
-asana sections create nix-and-code "Review plan"
-asana sections create nix-and-code "Review code"
-asana sections create nix-and-code "To fix"
+asana-cli sections create nix-and-code "Review plan"
+asana-cli sections create nix-and-code "Review code"
+asana-cli sections create nix-and-code "To fix"
 ```
 
 If an input section is missing, warn and skip it (no tasks to process).
@@ -48,8 +48,8 @@ If an input section is missing, warn and skip it (no tasks to process).
 ## Step 2 — Fetch tasks from input sections
 
 ```bash
-asana tasks list nix-and-code --section "Need plan"
-asana tasks list nix-and-code --section "Ready to implement"
+asana-cli tasks list nix-and-code --section "Need plan"
+asana-cli tasks list nix-and-code --section "Ready to implement"
 ```
 
 The list output includes each task's **GID and name** — that is all the main agent needs. Do NOT fetch full task details here; sub-agents handle that.
@@ -77,10 +77,10 @@ Moving a task = **create** in target section + **delete** original.
 
 ```bash
 # Create in target section (preserving name and description)
-asana tasks create nix-and-code "<task_name>" --section "<target_section>" --description "<original_description>"
+asana-cli tasks create nix-and-code "<task_name>" --section "<target_section>" --description "<original_description>"
 
 # Delete original
-asana tasks delete <original_task_gid>
+asana-cli tasks delete <original_task_gid>
 ```
 
 **Mapping:**
@@ -112,7 +112,7 @@ After all sub-agents finish, display a summary table:
 
 ## Error handling
 
-- **`asana` CLI not found:** Fail immediately with `"asana CLI not installed — install it and retry"`.
+- **`asana-cli` not found:** Fail immediately with `"asana-cli not installed — install it and retry"`.
 - **Sub-agent failure:** Do not move the task. Report the error. Continue with remaining tasks.
 - **Empty input sections:** Report "No tasks in <section>" and finish cleanly.
 - **Asana API error:** Report the error from the CLI stderr and skip the affected task.

--- a/programs/claude-code/skills/asana-dispatch/SKILL.md
+++ b/programs/claude-code/skills/asana-dispatch/SKILL.md
@@ -52,92 +52,26 @@ asana tasks list nix-and-code --section "Need plan"
 asana tasks list nix-and-code --section "Ready to implement"
 ```
 
-For each task in either section, fetch full details:
+The list output includes each task's **GID and name** — that is all the main agent needs. Do NOT fetch full task details here; sub-agents handle that.
 
-```bash
-asana tasks get <task_gid>
-```
-
-This returns the task name, description, subtasks, and completed status as JSON.
-
-Collect all tasks into two lists: `plan_tasks` and `ship_tasks`.
+Collect GIDs into two lists: `plan_tasks` and `ship_tasks`.
 
 ---
 
-## Step 3 — Validate target repo
-
-For each task, parse its **description** for an explicit repo mention.
-
-Recognized values:
-- `nix-configs` or `nix_configs` → `/home/romain/code/nix-configs`
-- `Main` → `/home/romain/code/Main`
-
-**Case-insensitive match.** Look for these as standalone words or path components in the description text.
-
-If no repo is found:
-1. Move the task to "To fix" (see Step 5)
-2. Log: `"Task '<name>' has no target repo in description — moved to To fix"`
-3. Skip to next task
-
----
-
-## Step 4 — Dispatch sub-agents
+## Step 3 — Dispatch sub-agents
 
 Launch up to **4 sub-agents concurrently** (mix of plan and ship tasks).
 
-### For "Need plan" tasks
+Each sub-agent is responsible for fetching its own task details and determining the target repo. The main agent only passes the **task GID** and **task name**.
 
-Launch a sub-agent per task with this prompt:
+- **"Need plan" tasks** → use the prompt template in [`plan-agent.md`](plan-agent.md)
+- **"Ready to implement" tasks** → use the prompt template in [`ship-agent.md`](ship-agent.md)
 
-> You are a planning agent. Your job is to produce a complete, detailed, implementation-ready plan. Do NOT write any code. Do NOT create branches.
->
-> **Task from Asana:**
-> - Title: `<task_name>`
-> - Description: `<task_description>`
-> - Subtasks: `<subtask_list>` (use these as chunking hints)
->
-> **Target repo:** `<repo_path>`
->
-> **Instructions:**
-> 1. `cd <repo_path>`
-> 2. Read `AGENTS.md` at the repo root if it exists.
-> 3. Read `~/.claude/docs/README.md` and any relevant docs.
-> 4. Read ALL relevant source files — existing behavior, data structures, API surfaces, tests.
-> 5. Write a detailed implementation plan at `~/.claude/plans/<slug>.md` following the standard format:
->    - `## Branch`, `## Short ID`, `## Category` headers
->    - Numbered top-level steps (1., 2., 3.) with lettered sub-points (A, B, C)
->    - A `## Chunks` section grouping work into independently-shippable units sized for a single sub-agent (1–3 files each), with an explicit dependency graph
-> 6. Update `~/.claude/plans/_index.json`.
-> 7. Return: the plan file path and a summary of what was planned.
->
-> Make the plan as detailed as possible. Every chunk should specify exact file paths to create/modify, the logic to implement, and how to verify.
-
-### For "Ready to implement" tasks
-
-Launch a sub-agent per task with this prompt:
-
-> You have a task to implement end-to-end.
->
-> **Task from Asana:**
-> - Title: `<task_name>`
-> - Description: `<task_description>`
-> - Subtasks: `<subtask_list>`
->
-> **Target repo:** `<repo_path>`
->
-> **Instructions:**
-> 1. `cd <repo_path>`
-> 2. Invoke `/ship` with the following task description:
->
-> `<task_name>: <task_description>`
->
-> The ship workflow handles everything: planning, implementation, testing, and self-review.
->
-> 3. Return: summary of what was implemented, commit hashes, and any open points.
+If a sub-agent returns `"AMBIGUOUS_REPO"`, treat it as a repo-resolution failure (see Step 4).
 
 ---
 
-## Step 5 — Move tasks on completion
+## Step 4 — Move tasks on completion
 
 Moving a task = **create** in target section + **delete** original.
 
@@ -151,16 +85,18 @@ asana tasks delete <original_task_gid>
 
 **Mapping:**
 
-| Source section | On success | On missing repo |
-|---|---|---|
-| Need plan | → Review plan | → To fix |
-| Ready to implement | → Review code | → To fix |
+| Source section | On success | On ambiguous repo | On failure |
+|---|---|---|---|
+| Need plan | → Review plan | → To fix | Stay in place |
+| Ready to implement | → Review code | → To fix | Stay in place |
+
+**On `AMBIGUOUS_REPO` result:** Move the task to "To fix". Append the sub-agent's ambiguity explanation to the task description (do not overwrite). Log: `"Task '<name>' — ambiguous target repo, moved to To fix"`.
 
 **On sub-agent failure:** do NOT move the task. Leave it in its current section so it can be retried.
 
 ---
 
-## Step 6 — Report
+## Step 5 — Report
 
 As each sub-agent completes, immediately report:
 - Task name

--- a/programs/claude-code/skills/asana-dispatch/plan-agent.md
+++ b/programs/claude-code/skills/asana-dispatch/plan-agent.md
@@ -1,0 +1,54 @@
+# Plan sub-agent prompt
+
+This file contains the prompt template for "Need plan" sub-agents dispatched by the main orchestrator.
+
+---
+
+## Prompt
+
+> You are a planning agent. Your job is to produce a complete, detailed, implementation-ready plan. Do NOT write any code. Do NOT create branches.
+>
+> **Asana task GID:** `<task_gid>`
+> **Task name:** `<task_name>`
+>
+> ---
+>
+> ### Step 1 — Fetch task details and determine the target repo
+>
+> 1. Run `asana tasks get <task_gid>` to fetch the full task details (description, subtasks).
+> 2. Parse the description for an explicit repo mention (case-insensitive):
+>    - `nix-configs` or `nix_configs` → `/home/romain/code/nix-configs`
+>    - `Main` → `/home/romain/code/Main`
+> 3. If no explicit mention, infer from the task content:
+>    - **nix-configs** — system settings, installed programs, Sway shortcuts, dotfiles, Nix configuration
+>    - **Main** — Rust crate behavior, library changes, service logic
+> 4. If still uncertain, check both repos for files you'd need to modify.
+> 5. If still ambiguous: **return `"AMBIGUOUS_REPO"` as your result** with an explanation of why. Do not proceed further.
+>
+> ---
+>
+> ### Step 2 — Research and plan
+>
+> 1. `cd <repo_path>`
+> 2. Read `AGENTS.md` at the repo root if it exists.
+> 3. Read `~/.claude/docs/README.md` and any relevant docs.
+> 4. Read ALL relevant source files — existing behavior, data structures, API surfaces, tests.
+> 5. Write a detailed implementation plan at `~/.claude/plans/<slug>.md` following the standard format:
+>    - `## Branch`, `## Short ID`, `## Category` headers
+>    - Numbered top-level steps (1., 2., 3.) with lettered sub-points (A, B, C)
+>    - A `## Chunks` section grouping work into independently-shippable units sized for a single sub-agent (1–3 files each), with an explicit dependency graph
+> 6. Update `~/.claude/plans/_index.json`.
+>
+> ---
+>
+> ### Step 3 — Update the Asana ticket
+>
+> Upload the plan file as an attachment to the task:
+>
+> ```bash
+> asana attachments upload <task_gid> ~/.claude/plans/<slug>.md
+> ```
+>
+> 7. Return: the target repo, the plan file path, and a summary of what was planned.
+>
+> Make the plan as detailed as possible. Every chunk should specify exact file paths to create/modify, the logic to implement, and how to verify.

--- a/programs/claude-code/skills/asana-dispatch/plan-agent.md
+++ b/programs/claude-code/skills/asana-dispatch/plan-agent.md
@@ -1,6 +1,6 @@
 # Plan sub-agent prompt
 
-This file contains the prompt template for "Need plan" sub-agents dispatched by the main orchestrator.
+This file contains the prompt template for "Ready to plan" sub-agents dispatched by the main orchestrator.
 
 ---
 

--- a/programs/claude-code/skills/asana-dispatch/plan-agent.md
+++ b/programs/claude-code/skills/asana-dispatch/plan-agent.md
@@ -15,7 +15,7 @@ This file contains the prompt template for "Need plan" sub-agents dispatched by 
 >
 > ### Step 1 — Fetch task details and determine the target repo
 >
-> 1. Run `asana tasks get <task_gid>` to fetch the full task details (description, subtasks).
+> 1. Run `asana-cli tasks get <task_gid>` to fetch the full task details (description, subtasks).
 > 2. Parse the description for an explicit repo mention (case-insensitive):
 >    - `nix-configs` or `nix_configs` → `/home/romain/code/nix-configs`
 >    - `Main` → `/home/romain/code/Main`
@@ -46,7 +46,7 @@ This file contains the prompt template for "Need plan" sub-agents dispatched by 
 > Upload the plan file as an attachment to the task:
 >
 > ```bash
-> asana attachments upload <task_gid> ~/.claude/plans/<slug>.md
+> asana-cli attachments upload <task_gid> ~/.claude/plans/<slug>.md
 > ```
 >
 > 7. Return: the target repo, the plan file path, and a summary of what was planned.

--- a/programs/claude-code/skills/asana-dispatch/ship-agent.md
+++ b/programs/claude-code/skills/asana-dispatch/ship-agent.md
@@ -15,7 +15,7 @@ This file contains the prompt template for "Ready to implement" sub-agents dispa
 >
 > ### Step 1 — Fetch task details and determine the target repo
 >
-> 1. Run `asana tasks get <task_gid>` to fetch the full task details (description, subtasks).
+> 1. Run `asana-cli tasks get <task_gid>` to fetch the full task details (description, subtasks).
 > 2. Parse the description for an explicit repo mention (case-insensitive):
 >    - `nix-configs` or `nix_configs` → `/home/romain/code/nix-configs`
 >    - `Main` → `/home/romain/code/Main`
@@ -43,10 +43,16 @@ This file contains the prompt template for "Ready to implement" sub-agents dispa
 >
 > ### Step 3 — Update the Asana ticket
 >
-> Append a summary of what was done to the task description (do not overwrite existing content):
+> 1. Add the branch short ID to the task name:
 >
 > ```bash
-> asana tasks update <task_gid> --description "<existing_description>\n\n---\n## Implementation summary\n<summary of what was implemented, commit hashes, branch name, and any open points>"
+> asana-cli tasks update <task_gid> --name "<short_id>-<task_name>"
+> ```
+>
+> 2. Append a summary of what was done to the task description (do not overwrite existing content):
+>
+> ```bash
+> asana-cli tasks update <task_gid> --description "<existing_description>\n\n---\n## Implementation summary\n<summary of what was implemented, commit hashes, branch name, and any open points>"
 > ```
 >
 > 4. Return: the target repo, summary of what was implemented, commit hashes, and any open points.

--- a/programs/claude-code/skills/asana-dispatch/ship-agent.md
+++ b/programs/claude-code/skills/asana-dispatch/ship-agent.md
@@ -1,0 +1,52 @@
+# Ship sub-agent prompt
+
+This file contains the prompt template for "Ready to implement" sub-agents dispatched by the main orchestrator.
+
+---
+
+## Prompt
+
+> You have a task to implement end-to-end.
+>
+> **Asana task GID:** `<task_gid>`
+> **Task name:** `<task_name>`
+>
+> ---
+>
+> ### Step 1 — Fetch task details and determine the target repo
+>
+> 1. Run `asana tasks get <task_gid>` to fetch the full task details (description, subtasks).
+> 2. Parse the description for an explicit repo mention (case-insensitive):
+>    - `nix-configs` or `nix_configs` → `/home/romain/code/nix-configs`
+>    - `Main` → `/home/romain/code/Main`
+> 3. If no explicit mention, infer from the task content:
+>    - **nix-configs** — system settings, installed programs, Sway shortcuts, dotfiles, Nix configuration
+>    - **Main** — Rust crate behavior, library changes, service logic
+> 4. If still uncertain, check both repos for files you'd need to modify.
+> 5. If still ambiguous: **return `"AMBIGUOUS_REPO"` as your result** with an explanation of why. Do not proceed further.
+>
+> ---
+>
+> ### Step 2 — Implement
+>
+> 1. `cd <repo_path>`
+> 2. Check if the task description contains an implementation plan (from a previous planning pass). If it does, use it to guide the implementation.
+> 3. Invoke `/ship` with the following task description:
+>
+> `<task_name>: <task_description>`
+>
+> If a plan was found in step 2, append it to the ship prompt so it is used as the implementation plan.
+>
+> The ship workflow handles everything: planning, implementation, testing, and self-review.
+>
+> ---
+>
+> ### Step 3 — Update the Asana ticket
+>
+> Append a summary of what was done to the task description (do not overwrite existing content):
+>
+> ```bash
+> asana tasks update <task_gid> --description "<existing_description>\n\n---\n## Implementation summary\n<summary of what was implemented, commit hashes, branch name, and any open points>"
+> ```
+>
+> 4. Return: the target repo, summary of what was implemented, commit hashes, and any open points.

--- a/programs/claude-code/skills/asana-dispatch/ship-agent.md
+++ b/programs/claude-code/skills/asana-dispatch/ship-agent.md
@@ -39,6 +39,16 @@ This file contains the prompt template for "Ready to implement" sub-agents dispa
 >
 > The ship workflow handles everything: planning, implementation, testing, and self-review.
 >
+> **If you cannot proceed** — contradictions in the plan, ambiguities, design decisions that require human input, or insufficient information — do NOT attempt a partial implementation. Instead:
+>
+> 1. Write (or update) a plan at `~/.claude/plans/<slug>.md` documenting:
+>    - Everything that is known and validated (repo structure, affected files, clear requirements)
+>    - All open questions, contradictions, and decisions that need human input — clearly separated
+> 2. Update `~/.claude/plans/_index.json`.
+> 3. Upload the plan to the task: `asana-cli attachments upload <task_gid> ~/.claude/plans/<slug>.md`
+> 4. Append to the task description why implementation was blocked and list the main decisions to be taken.
+> 5. **Return `"NEEDS_INPUT"` as your result** with a summary of the blockers. Do not proceed further.
+>
 > ---
 >
 > ### Step 3 — Update the Asana ticket

--- a/programs/claude-code/workstation.nix
+++ b/programs/claude-code/workstation.nix
@@ -2,10 +2,19 @@
   config,
   lib,
   pkgs,
+  pkgsUnstable,
   ...
 }:
 let
   inherit (config.byDb) modifier ws paths;
+  homeDir = config.home.homeDirectory;
+  asanaDispatchScript = pkgs.writeShellScript "asana-dispatch" ''
+    export PATH="${homeDir}/.nix-profile/bin:/run/current-system/sw/bin:$PATH"
+    cd "${homeDir}"
+    exec ${pkgsUnstable.claude-code}/bin/claude \
+      --dangerously-skip-permissions \
+      -p "Read and follow the skill at ~/.claude/skills/asana-dispatch/SKILL.md"
+  '';
   rofi = config.rofi.defaultCmd;
   # Lists worktree display names: prefix stays as-is, prefix_foo becomes "foo"
   # $1 = base path, $2 = prefix (default: Main)
@@ -93,6 +102,27 @@ let
 in
 {
   imports = [ ./common.nix ];
+
+  systemd.user.services.asana-dispatch = {
+    Unit.Description = "Run asana-dispatch skill via Claude Code";
+    Service = {
+      Type = "oneshot";
+      ExecStart = asanaDispatchScript;
+      TimeoutStartSec = "infinity";
+    };
+  };
+
+  systemd.user.timers.asana-dispatch = {
+    Unit.Description = "Trigger asana-dispatch hourly 8–20 and at midnight";
+    Install.WantedBy = [ "timers.target" ];
+    Timer = {
+      OnCalendar = [
+        "*-*-* 00:00:00"
+        "*-*-* 8..20:00:00"
+      ];
+      Persistent = true;
+    };
+  };
 
   wayland.windowManager.sway.config = {
     keybindings = lib.mkOptionDefault {


### PR DESCRIPTION
Add an `asana-dispatch` skill that fetches tasks from Asana board sections and dispatches sub-agents to plan or ship them. Includes a systemd user timer to run it hourly (8–20h + midnight).

**Changes:**
- **New skill** (`skills/asana-dispatch/`): orchestrator (`SKILL.md`), plan sub-agent prompt (`plan-agent.md`), ship sub-agent prompt (`ship-agent.md`)
- **asana-cli** added to workstation packages with `nix-and-code` project config
- **systemd timer/service** (`asana-dispatch.timer` + `.service`) to run the skill on schedule
- **Claude wrapper cleanup**: removed PulseAudio forwarding and `sox` dependency, renamed `claudeWithVoice` → `claudeWrapper`